### PR TITLE
Propagate SLF4J MDC map across async event invocations

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -17,8 +17,8 @@ grails.project.dependency.resolution = {
 
         // uncomment the below to enable remote dependency resolution
         // from public Maven repositories
-        //mavenCentral()
-        //mavenLocal()
+        mavenCentral()
+        mavenLocal()
         //mavenRepo "http://snapshots.repository.codehaus.org"
         //mavenRepo "http://repository.codehaus.org"
         //mavenRepo "http://download.java.net/maven/2/"

--- a/src/java/org/grails/plugin/platform/events/EventMessage.java
+++ b/src/java/org/grails/plugin/platform/events/EventMessage.java
@@ -18,6 +18,7 @@
 package org.grails.plugin.platform.events;
 
 import org.grails.plugin.platform.events.dispatcher.GormTopicSupport;
+import org.slf4j.MDC;
 
 import java.io.Serializable;
 import java.util.Map;
@@ -37,6 +38,7 @@ public class EventMessage<D> implements Serializable {
     final private D data;
     final private Boolean gormSession;
     final private Map<String, String> headers;
+    final private Map mdc;
 
     public EventMessage(String event, D data) {
         this(event, data, null);
@@ -56,6 +58,7 @@ public class EventMessage<D> implements Serializable {
         this.namespace = namespace;
         this.gormSession = gormSession;
         this.headers = headers;
+        this.mdc = MDC.getCopyOfContextMap();
     }
 
     public D getData() {
@@ -79,5 +82,9 @@ public class EventMessage<D> implements Serializable {
 
     public Map<String, String> getHeaders() {
         return headers;
+    }
+
+    public Map getMdc() {
+        return mdc;
     }
 }

--- a/src/java/org/grails/plugin/platform/events/publisher/DefaultEventsPublisher.java
+++ b/src/java/org/grails/plugin/platform/events/publisher/DefaultEventsPublisher.java
@@ -23,6 +23,7 @@ import org.codehaus.groovy.grails.support.PersistenceContextInterceptor;
 import org.grails.plugin.platform.events.EventMessage;
 import org.grails.plugin.platform.events.EventReply;
 import org.grails.plugin.platform.events.registry.DefaultEventsRegistry;
+import org.slf4j.MDC;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -141,6 +142,10 @@ public class DefaultEventsPublisher implements EventsPublisher, ApplicationConte
         }
 
         public DefaultEventsRegistry.InvokeResult call() {
+
+            // Populate the MDC inherited from the calling environment
+            MDC.setContextMap(event.getMdc());
+
             boolean gormSession = persistenceInterceptor != null && event.isGormSession();
             if (gormSession) {
                 persistenceInterceptor.init();


### PR DESCRIPTION
The logging Mapped Diagnostic Context of the event-firing thread is not available to the event execution threads, since they are not created by the calling thread. This means MDC cannot be used with async events unless the MDC is passed into the thread executing the event listener. The MDC can be passed in by including it as a property on the EventMessage, populated on instantiation of the EventMessage and loaded into the invocations thread's MDC before the listeners are executed.
