### PR TITLE
Log errors coming out listeners and increase the severity

### DIFF
--- a/src/java/org/grails/plugin/platform/events/registry/DefaultEventsRegistry.java
+++ b/src/java/org/grails/plugin/platform/events/registry/DefaultEventsRegistry.java
@@ -243,9 +243,7 @@ public class DefaultEventsRegistry implements EventsRegistry {
                     log.debug("Ignoring call to " + bean.getClass() + "." + method.getName() + " with args " + arg.toString() + " - illegal arg exception: " + e.toString());
                 }
             } catch (InvocationTargetException e) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Failing call to " + bean.getClass() + "." + method.getName() + " with args " + arg.toString() + " - illegal arg invokation " + e.toString());
-                }
+                log.warn("Failing call to " + bean.getClass() + "." + method.getName() + " with args " + arg.toString() + " - illegal arg invokation " + e.toString(), e.getCause());
                 throw e.getCause();
             } catch (Throwable e) {
                 if (log.isDebugEnabled()) {


### PR DESCRIPTION
Right now if a listener throws an exception during an async event the stack of that error and the original exception is never logged at all even at trace level. We are currently working around this by adding a onError block to every event call that logs each of the returned errors so we can know if something is failing unexpectedly. 

Suggested changes in pull request:
1. Add the exception to the log statement that is already there.
2. Increase the severity from debug to warn.

*Note: There is a throw already in the block that picks up the error which works fine when its called in the same thread. But when its run in the async executor the throw doesnt seem to get caught by anyone else.
