### PR TITLE
Updated documentation for displayMessage and displayFlashMessage UI Extension Methods

### DIFF
--- a/src/docs/ref/Ui Extension Methods/displayFlashMessage.gdoc
+++ b/src/docs/ref/Ui Extension Methods/displayFlashMessage.gdoc
@@ -19,7 +19,7 @@ The @args@ supported are:
 {table}
 *Name* | *Purpose*
 text | The text of the label, or an i18n code to resolve to use as the text
-textArgs | Optional arguments to pass when creating the i18n message text
+args | Optional arguments to pass when creating the i18n message text
 type | Optional message type indicator i.e. 'warning', 'error', 'info', 'debug'
 {table}
 

--- a/src/docs/ref/Ui Extension Methods/displayMessage.gdoc
+++ b/src/docs/ref/Ui Extension Methods/displayMessage.gdoc
@@ -19,7 +19,7 @@ If using the Map arguments form, the @args@ supported are:
 {table}
 *Name* | *Purpose*
 text | The text of the label, or an i18n code to resolve to use as the text
-textArgs | Optional arguments to pass when creating the i18n message text
+args | Optional arguments to pass when creating the i18n message text
 type | Optional message type indicator i.e. 'warning', 'error', 'info', 'debug'
 class | Optional CSS class to apply
 cssPrefix | Optional prefix to apply if "type" is supplied, prepended to the type name


### PR DESCRIPTION
Updated documentation for displayMessage and displayFlashMessage UI Extension Methods by modifying the "textArgs" argument name to "args". This more accurately reflects what the code is expecting.
